### PR TITLE
Update OCP311.md

### DIFF
--- a/OCP311.md
+++ b/OCP311.md
@@ -387,8 +387,17 @@ Below are the sequences of steps needed to prepare the worker, master and loadba
 
 * [ ] 2. Install ansible on Bastion host
 ```
-	yum install -y ansible
+	rpm -ivh https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.6.19-1.el7.ans.noarch.rpm
+```	
+	This command gets ansible version 2.6.19 from the internet.  If you do not have access to the internet, from a machine that does         have access to the internet run these command to get the rpm
 ```
+	yum install -y
+	wget https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.6.19-1.el7.ans.noarch.rpm
+```
+	Then move the `ansible-2.6.19-1.el7.ans.noarch.rpm` file to bastion host and run this command to install it    
+	`rpm -ivh ansible-2.6.19-1.el7.ans.noarch.rpm`    
+	Do not use `yum install -y ansible` as this will not install the correct version of ansible. 
+
         ensure, it is installing the ansible version 2.6.19
 ```
         ansible --version


### PR DESCRIPTION
fixed instructions to install ansible 2.6.19 better than the pip commands and instructions i gave earlier  
rpm -ivh https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.6.19-1.el7.ans.noarch.rpm